### PR TITLE
Fix/init settings persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,26 @@ Triggered by `/worktree list` (selecting an existing worktree) and by
 `/worktree create` when the branch already exists and you confirm switching.
 
 - Accepts a single string or an array of strings
+- Runs with the selected worktree's path as the child process cwd
 - Supports all template variables (`{{path}}`, `{{name}}`, `{{branch}}`, `{{project}}`, `{{mainWorktree}}`)
 - Not configured by default
+
+> **What "switch" does today.** In the current version of this extension,
+> `onSwitch` does **not** change the running pi session's working directory.
+> It is a hook for opening pi (or any other workflow) in the selected
+> worktree — typically a new terminal tab, tmux/zellij pane, or IDE window
+> rooted at `{{path}}`. Without an `onSwitch`, `/worktree list` only prints
+> the path and next-step suggestions. A future release of this extension
+> plans to switch the running session in place on sufficiently recent pi
+> builds; until that lands, the multiplexer / relaunch workflow below is the
+> recommended setup.
+>
+> Typical `onSwitch` values:
+> ```
+> zellij action new-tab --cwd {{path}} -- pi
+> tmux new-window -c {{path}} pi
+> osascript -e 'tell app "Terminal" to do script "cd {{path}} && pi"'
+> ```
 
 ### `onBeforeRemove`
 
@@ -494,6 +512,25 @@ Use `/worktree remove <name>`, then confirm the force remove prompt.
 
 ### `cd` does not switch shell directory
 `/worktree cd` prints the path; it does not directly mutate your shell state.
+
+### `/worktree list` doesn’t change my pi session’s directory
+The current version of this extension does not move the running pi session
+when you pick a worktree. It runs your `onSwitch` hook (if any) with the
+worktree’s path as the child process’s cwd, and prints the path. To actually
+work in a worktree you have two options today:
+
+- **Start a fresh pi there.** Exit the current session and run
+  `cd /path/to/worktree && pi`. Each cwd keeps its own session history under
+  `~/.pi/agent/sessions/<encoded-cwd>/`.
+- **Configure an `onSwitch` hook that spawns pi in a new tab/window.** See the
+  [`onSwitch`](#onswitch) section above for example commands. Because
+  `onSwitch` children already run rooted at `{{path}}`, a plain `pi` inside
+  the hook resolves correctly.
+
+Note: recent pi builds (≥ 0.65.0) expose runtime APIs that make true
+in-place cwd switching possible, and a future release of this extension
+plans to use them so `/worktree list` can redirect the current session
+directly.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This creates a new Zellij tab with Neovim and Pi running in the new worktree pat
 |---|---|
 | `/worktree init` | Interactive setup for extension settings |
 | `/worktree settings` | Show all current settings |
-| `/worktree settings <key>` | Get one setting (`worktreeRoot`, `parentDir` alias, `onCreate`) |
+| `/worktree settings <key>` | Get one setting (`worktreeRoot`, `parentDir` alias, `onCreate`, `onSwitch`, `onBeforeRemove`, `branchNameGenerator`) |
 | `/worktree settings <key> <value>` | Set one setting |
 | `/worktree create <branch> [--name <worktree-name>]`<br/>`/worktree create --generate [--name <worktree-name>] <prompt-or-name>` | Create a new worktree from `<branch>` (default mode) or generate one via configured `branchNameGenerator` (opt-in with `--generate`) |
 | `/worktree list` | List all worktrees (`/worktree ls` alias) |
@@ -129,7 +129,9 @@ This creates a new Zellij tab with Neovim and Pi running in the new worktree pat
 
 ## Configuration
 
-Settings live in `~/.pi/agent/pi-worktrees-settings.json`.
+Settings live in `~/.pi/agent/pi-worktrees.config.json` (resolved by
+`@zenobius/pi-extension-config`). Run `/worktree status` to print the exact
+path.
 
 ```json
 {
@@ -137,11 +139,17 @@ Settings live in `~/.pi/agent/pi-worktrees-settings.json`.
     "github.com/org/repo": {
       "worktreeRoot": "~/work/org/repo.worktrees",
       "onCreate": ["mise install", "bun install"],
+      "onSwitch": "mise run dev:resume",
+      "onBeforeRemove": "bun test"
     },
     "github.com/org/*": {
       "worktreeRoot": "~/work/org/shared.worktrees",
       "onCreate": "mise setup",
       "branchNameGenerator": "pi -p \"branch name for $PI_WORKTREE_PROMPT\" --model local/model"
+    },
+    "**": {
+      "worktreeRoot": "~/.local/share/worktrees/{{project}}",
+      "onCreate": "mise setup"
     }
   },
   "matchingStrategy": "fail-on-tie",
@@ -151,11 +159,7 @@ Settings live in `~/.pi/agent/pi-worktrees-settings.json`.
   "onCreateCmdDisplayError": "[ ] {{cmd}} [ERROR]",
   "onCreateCmdDisplayPendingColor": "dim",
   "onCreateCmdDisplaySuccessColor": "success",
-  "onCreateCmdDisplayErrorColor": "error",
-  "worktree": {
-    "worktreeRoot": "~/.local/share/worktrees/{{project}}",
-    "onCreate": "mise setup"
-  }
+  "onCreateCmdDisplayErrorColor": "error"
 }
 ```
 
@@ -164,6 +168,10 @@ Settings live in `~/.pi/agent/pi-worktrees-settings.json`.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `worktrees` | `Record<string, WorktreeSettings>` | `{}` | Pattern-matched settings by repo URL or glob. |
+| `worktrees[*].worktreeRoot` | `string` | `{{mainWorktree}}.worktrees` | Parent directory for new worktrees. |
+| `worktrees[*].onCreate` | `string \| string[]` | `echo "Created {{path}}"` | Command(s) run after creating a new worktree. |
+| `worktrees[*].onSwitch` | `string \| string[]` | unset | Command(s) run when switching to an existing worktree via `/worktree list` or when re-selecting in `/worktree create`. |
+| `worktrees[*].onBeforeRemove` | `string \| string[]` | unset | Command(s) run before `/worktree remove`. A non-zero exit blocks removal. |
 | `matchingStrategy` | `'fail-on-tie' \| 'first-wins' \| 'last-wins'` | `fail-on-tie` | Tie-break behavior for equally specific patterns. |
 | `onCreateDisplayOutputMaxLines` | `number` (integer, `>= 0`) | `5` | Number of latest stdout/stderr lines shown in live UI updates during `onCreate`. |
 | `onCreateCmdDisplayPending` | `string` | `[ ] {{cmd}}` | Template for pending/running command display lines. |
@@ -173,7 +181,7 @@ Settings live in `~/.pi/agent/pi-worktrees-settings.json`.
 | `onCreateCmdDisplaySuccessColor` | `string` | `success` | Pi theme color name for successful command lines. |
 | `onCreateCmdDisplayErrorColor` | `string` | `error` | Pi theme color name for failed command lines. |
 | `worktrees[*].branchNameGenerator` | `string` | unset | Optional command used only by `/worktree create --generate ...`. Must print exactly one branch name to stdout. Receives `$PI_WORKTREE_PROMPT` env var and supports `{{prompt}}` / `{prompt}` token replacement. |
-| `worktree` (legacy) | `WorktreeSettings` | n/a | Legacy fallback shape; migrated automatically. |
+| `worktree` (legacy) | `WorktreeSettings` | n/a | Legacy fallback shape; migrated automatically to `worktrees["**"]`. |
 
 ### Matching model
 
@@ -236,6 +244,26 @@ Where new worktrees are created.
 
 > Backward compatibility: `parentDir` is still accepted as a deprecated alias for `worktreeRoot`.
 > The extension will migrate existing `parentDir` values to `worktreeRoot` automatically.
+
+### `onSwitch`
+
+Command(s) run when a worktree is re-selected rather than created.
+Triggered by `/worktree list` (selecting an existing worktree) and by
+`/worktree create` when the branch already exists and you confirm switching.
+
+- Accepts a single string or an array of strings
+- Supports all template variables (`{{path}}`, `{{name}}`, `{{branch}}`, `{{project}}`, `{{mainWorktree}}`)
+- Not configured by default
+
+### `onBeforeRemove`
+
+Command(s) run before `/worktree remove` removes the worktree. Useful as a
+confirmation or safety gate (e.g. run tests, sync state).
+
+- Accepts a single string or an array of strings
+- A non-zero exit blocks removal
+- Supports all template variables
+- Not configured by default
 ### Create command naming contract
 
 `/worktree create` is branch-first:
@@ -388,6 +416,13 @@ This extension does not apply a separate ad-hoc deprecation mechanism.
   |                           |
   |                          yes
   |                           v
+  |                 [Run onBeforeRemove?]
+  |                    |non-zero exit
+  |                    v
+  |                 [Blocked] ------------------> [Idle]
+  |                    |
+  |                   pass / not configured
+  |                    v
   |                 [git worktree remove]
   |                    |fail (dirty worktree)
   |                    v
@@ -404,7 +439,12 @@ This extension does not apply a separate ad-hoc deprecation mechanism.
   |                    v
   |                 [Success] -------------------> [Idle]
   |
-  +--> [list | status | cd] ---------------------> [Display info] --> [Idle]
+  +--> [list] --> [Select worktree]
+  |                 |
+  |                 v
+  |           [Run onSwitch?] ------------------> [Print path] --> [Idle]
+  |
+  +--> [status | cd] ----------------------------> [Display info] --> [Idle]
   |
   +--> [prune] --> [dry-run stale refs]
                       |none

--- a/src/cmds/cmdCreate.ts
+++ b/src/cmds/cmdCreate.ts
@@ -69,8 +69,8 @@ export async function cmdCreate(
     }
 
     const confirmMessage = current.onSwitch
-      ? `Path: ${existingWorktree.path}\nBranch: ${existingWorktree.branch}\n\nSwitch to this worktree and run onSwitch?`
-      : `Path: ${existingWorktree.path}\nBranch: ${existingWorktree.branch}\n\nSwitch to this worktree?`;
+      ? `Path: ${existingWorktree.path}\nBranch: ${existingWorktree.branch}\n\nRun onSwitch for this worktree?`
+      : `Path: ${existingWorktree.path}\nBranch: ${existingWorktree.branch}\n\nShow this worktree's path? (This version of the extension does not redirect the running pi session; configure an onSwitch hook to open pi in this worktree automatically.)`;
     const shouldSwitch = await ctx.ui.confirm('Worktree already exists', confirmMessage);
 
     if (!shouldSwitch) {
@@ -116,6 +116,23 @@ export async function cmdCreate(
       return;
     }
     ctx.ui.notify(`Worktree path: ${existingWorktree.path}`, 'info');
+    if (current.onSwitch) {
+      ctx.ui.notify(
+        `onSwitch finished. Note: this pi session has not been moved to ${existingWorktree.path} — in this version of the extension, onSwitch is expected to have opened pi there in a separate tab/window/pane.`,
+        'info'
+      );
+    } else {
+      ctx.ui.notify(
+        [
+          'Note: in this version of the extension, /worktree create does not',
+          'redirect the running pi session to the selected worktree.',
+          'To work in this worktree, either:',
+          `  • exit and run: cd ${existingWorktree.path} && pi`,
+          '  • configure /worktree settings onSwitch "<command that spawns pi in a new tab/window>"',
+        ].join('\n'),
+        'info'
+      );
+    }
     return;
   }
 

--- a/src/cmds/cmdInit.ts
+++ b/src/cmds/cmdInit.ts
@@ -1,6 +1,15 @@
 import type { ExtensionCommandContext } from '@mariozechner/pi-coding-agent';
 import type { CommandDeps } from '../types.ts';
+import { saveWorktreeSettings } from '../services/config/config.ts';
 import { WorktreeSettingsConfig, getConfiguredWorktreeRoot } from '../services/config/schema.ts';
+
+function formatHookValue(value: WorktreeSettingsConfig['onCreate']): string {
+  if (!value) {
+    return '';
+  }
+
+  return Array.isArray(value) ? value.join(' && ') : value;
+}
 
 export async function cmdInit(
   _args: string,
@@ -17,15 +26,21 @@ export async function cmdInit(
 
   ctx.ui.notify('Worktree Extension Setup\n━━━━━━━━━━━━━━━━━━━━━━━━', 'info');
 
-  if (currentWorktreeRoot || currentSettings.onCreate) {
-    const current = [
-      'Current settings:',
-      currentWorktreeRoot ? `  worktreeRoot: ${currentWorktreeRoot}` : null,
-      currentSettings.onCreate ? `  onCreate: ${currentSettings.onCreate}` : null,
-    ]
-      .filter(Boolean)
-      .join('\n');
-    ctx.ui.notify(current, 'info');
+  const currentLines = [
+    'Current settings:',
+    currentWorktreeRoot ? `  worktreeRoot: ${currentWorktreeRoot}` : null,
+    currentSettings.onCreate ? `  onCreate: ${formatHookValue(currentSettings.onCreate)}` : null,
+    currentSettings.onSwitch ? `  onSwitch: ${formatHookValue(currentSettings.onSwitch)}` : null,
+    currentSettings.onBeforeRemove
+      ? `  onBeforeRemove: ${formatHookValue(currentSettings.onBeforeRemove)}`
+      : null,
+    currentSettings.branchNameGenerator
+      ? `  branchNameGenerator: ${currentSettings.branchNameGenerator}`
+      : null,
+  ].filter(Boolean) as string[];
+
+  if (currentLines.length > 1) {
+    ctx.ui.notify(currentLines.join('\n'), 'info');
   }
 
   const PARENT_DIR_DEFAULT = 'Default ({{mainWorktree}}.worktrees)';
@@ -72,12 +87,10 @@ export async function cmdInit(
     worktreeRoot = currentWorktreeRoot;
   }
 
-  const onCreateDefault = Array.isArray(currentSettings.onCreate)
-    ? currentSettings.onCreate.join(' && ')
-    : (currentSettings.onCreate ?? 'mise setup');
+  const onCreateDefault = formatHookValue(currentSettings.onCreate) || 'mise setup';
 
   const onCreate = await ctx.ui.input(
-    'Enter command to run after creating worktree (or leave empty):\nSupports: {{path}}, {{name}}, {{branch}}, {{project}}, {{mainWorktree}}',
+    'Enter command to run after creating a new worktree (or leave empty):\nSupports: {{path}}, {{name}}, {{branch}}, {{project}}, {{mainWorktree}}',
     onCreateDefault
   );
 
@@ -86,13 +99,58 @@ export async function cmdInit(
     return;
   }
 
-  const newSettings: WorktreeSettingsConfig = {};
-  if (worktreeRoot) {
-    newSettings.worktreeRoot = worktreeRoot;
+  const onSwitchDefault = formatHookValue(currentSettings.onSwitch);
+
+  const onSwitch = await ctx.ui.input(
+    'Enter command to run when switching to an existing worktree (or leave empty):\nSupports: {{path}}, {{name}}, {{branch}}, {{project}}, {{mainWorktree}}',
+    onSwitchDefault
+  );
+
+  if (onSwitch === undefined) {
+    ctx.ui.notify('Setup cancelled', 'info');
+    return;
   }
 
-  if (onCreate && onCreate.trim()) {
-    newSettings.onCreate = onCreate.trim();
+  const onBeforeRemoveDefault = formatHookValue(currentSettings.onBeforeRemove);
+
+  const onBeforeRemove = await ctx.ui.input(
+    'Enter command to run before removing a worktree (non-zero exit blocks removal, or leave empty):\nSupports: {{path}}, {{name}}, {{branch}}, {{project}}, {{mainWorktree}}',
+    onBeforeRemoveDefault
+  );
+
+  if (onBeforeRemove === undefined) {
+    ctx.ui.notify('Setup cancelled', 'info');
+    return;
+  }
+
+  const newSettings: WorktreeSettingsConfig = {};
+  const clearKeys: (keyof WorktreeSettingsConfig)[] = [];
+
+  if (worktreeRoot) {
+    newSettings.worktreeRoot = worktreeRoot;
+  } else {
+    clearKeys.push('worktreeRoot', 'parentDir');
+  }
+
+  const trimmedOnCreate = onCreate.trim();
+  if (trimmedOnCreate) {
+    newSettings.onCreate = trimmedOnCreate;
+  } else {
+    clearKeys.push('onCreate');
+  }
+
+  const trimmedOnSwitch = onSwitch.trim();
+  if (trimmedOnSwitch) {
+    newSettings.onSwitch = trimmedOnSwitch;
+  } else {
+    clearKeys.push('onSwitch');
+  }
+
+  const trimmedOnBeforeRemove = onBeforeRemove.trim();
+  if (trimmedOnBeforeRemove) {
+    newSettings.onBeforeRemove = trimmedOnBeforeRemove;
+  } else {
+    clearKeys.push('onBeforeRemove');
   }
 
   const preview = [
@@ -102,6 +160,12 @@ export async function cmdInit(
       ? `  worktreeRoot: "${newSettings.worktreeRoot}"`
       : '  worktreeRoot: (default)',
     newSettings.onCreate ? `  onCreate: "${newSettings.onCreate}"` : '  onCreate: (none)',
+    newSettings.onSwitch ? `  onSwitch: "${newSettings.onSwitch}"` : '  onSwitch: (none)',
+    newSettings.onBeforeRemove
+      ? `  onBeforeRemove: "${newSettings.onBeforeRemove}"`
+      : '  onBeforeRemove: (none)',
+    '',
+    `Target file: ${deps.configService.getConfigPath('home')}`,
     '',
   ].join('\n');
 
@@ -113,13 +177,10 @@ export async function cmdInit(
   }
 
   try {
-    // TODO: See todo in ./cmds/cmdSettings.ts about saving paradigm
-
-    // await saveWorktreeSettings(deps.configService, { fallback: newSettings }); /
-    ctx.ui.notify(`✓ Settings saved`, 'info');
-
-    const finalConfig = JSON.stringify({ worktree: newSettings }, null, 2);
-    ctx.ui.notify(`Configuration:\n${finalConfig}`, 'info');
+    await saveWorktreeSettings(deps.configService, {
+      fallback: { set: newSettings, clear: clearKeys },
+    });
+    ctx.ui.notify(`✓ Settings saved to ${deps.configService.getConfigPath('home')}`, 'info');
   } catch (err) {
     ctx.ui.notify(`Failed to save settings: ${(err as Error).message}`, 'error');
   }

--- a/src/cmds/cmdList.ts
+++ b/src/cmds/cmdList.ts
@@ -49,7 +49,7 @@ export const cmdList: CmdHandler = async (_args, ctx, deps) => {
 
   const options = worktrees.map(formatWorktreeOption);
   const byOption = new Map(options.map((option, index) => [option, worktrees[index]]));
-  const selected = await ctx.ui.select('Select worktree to switch to', options);
+  const selected = await ctx.ui.select('Select a worktree', options);
 
   if (selected === undefined) {
     ctx.ui.notify('Cancelled', 'info');
@@ -65,7 +65,26 @@ export const cmdList: CmdHandler = async (_args, ctx, deps) => {
   const current = deps.configService.current({ cwd: target.path });
 
   if (!current.onSwitch) {
-    ctx.ui.notify(`No onSwitch configured for: ${target.path}`, 'info');
+    ctx.ui.notify(
+      [
+        `Worktree path: ${target.path}`,
+        `Branch:        ${target.branch}`,
+        '',
+        'Note: in this version of the extension, /worktree list does not',
+        'redirect the running pi session to the selected worktree. It runs',
+        'your onSwitch hook (if configured) and prints the path.',
+        '',
+        'To work in this worktree, either:',
+        `  • exit and run: cd ${target.path} && pi`,
+        '  • configure an onSwitch hook that spawns pi there in a new',
+        '    terminal/tab, e.g.:',
+        "      /worktree settings onSwitch 'zellij action new-tab --cwd {{path}} -- pi'",
+        `      (or: tmux new-window -c {{path}} pi)`,
+        '',
+        'See /worktree init for an interactive setup, or the README for details.',
+      ].join('\n'),
+      'info'
+    );
     return;
   }
 
@@ -115,6 +134,10 @@ export const cmdList: CmdHandler = async (_args, ctx, deps) => {
 
     stopBusy();
     deps.statusService.positive(ctx, `onSwitch complete: ${target.branch}`);
+    ctx.ui.notify(
+      `onSwitch finished. Note: this pi session has not been moved to ${target.path} — in this version of the extension, onSwitch is expected to have opened pi there in a separate tab/window/pane.`,
+      'info'
+    );
   } catch (err) {
     stopBusy();
     deps.statusService.critical(ctx, `onSwitch failed`);

--- a/src/cmds/cmdSettings.ts
+++ b/src/cmds/cmdSettings.ts
@@ -1,9 +1,26 @@
 import type { ExtensionCommandContext } from '@mariozechner/pi-coding-agent';
 import type { CommandDeps } from '../types.ts';
-import { getConfiguredWorktreeRoot } from '../services/config/schema.ts';
+import { saveWorktreeSettings } from '../services/config/config.ts';
+import { WorktreeSettingsConfig, getConfiguredWorktreeRoot } from '../services/config/schema.ts';
 
-const VALID_SETTING_KEYS = ['worktreeRoot', 'parentDir', 'onCreate'] as const;
+const VALID_SETTING_KEYS = [
+  'worktreeRoot',
+  'parentDir',
+  'onCreate',
+  'onSwitch',
+  'onBeforeRemove',
+  'branchNameGenerator',
+] as const;
 type SettingKey = (typeof VALID_SETTING_KEYS)[number];
+type ResolvedKey = Exclude<SettingKey, 'parentDir'>;
+
+function formatHookValue(value: WorktreeSettingsConfig['onCreate']): string {
+  if (!value) {
+    return '(none)';
+  }
+
+  return Array.isArray(value) ? value.join(' && ') : value;
+}
 
 export async function cmdSettings(
   args: string,
@@ -24,12 +41,15 @@ export async function cmdSettings(
       'Worktree Settings:',
       '━━━━━━━━━━━━━━━━━━',
       '',
-      `worktreeRoot: ${getConfiguredWorktreeRoot(currentSettings) || '(default: {{mainWorktree}}.worktrees)'}`,
-      `onCreate:     ${
-        Array.isArray(currentSettings.onCreate)
-          ? currentSettings.onCreate.join(' && ')
-          : (currentSettings.onCreate ?? '(none)')
+      `worktreeRoot:        ${
+        getConfiguredWorktreeRoot(currentSettings) || '(default: {{mainWorktree}}.worktrees)'
       }`,
+      `onCreate:            ${formatHookValue(currentSettings.onCreate)}`,
+      `onSwitch:            ${formatHookValue(currentSettings.onSwitch)}`,
+      `onBeforeRemove:      ${formatHookValue(currentSettings.onBeforeRemove)}`,
+      `branchNameGenerator: ${currentSettings.branchNameGenerator ?? '(none)'}`,
+      '',
+      `Config file: ${deps.configService.getConfigPath('home')}`,
       '',
     ];
     ctx.ui.notify(lines.join('\n'), 'info');
@@ -48,17 +68,15 @@ export async function cmdSettings(
     ctx.ui.notify('`parentDir` is deprecated. Use `worktreeRoot`.', 'warning');
   }
 
-  const resolvedKey: 'worktreeRoot' | 'onCreate' = key === 'parentDir' ? 'worktreeRoot' : key;
+  const resolvedKey: ResolvedKey = key === 'parentDir' ? 'worktreeRoot' : key;
 
   if (!value && parts.length === 1) {
     if (resolvedKey === 'worktreeRoot') {
       const currentValue = getConfiguredWorktreeRoot(currentSettings);
-      if (currentValue) {
-        ctx.ui.notify('worktreeRoot: ' + currentValue, 'info');
-        return;
-      }
-
-      ctx.ui.notify('worktreeRoot: (default: {{mainWorktree}}.worktrees)', 'info');
+      ctx.ui.notify(
+        'worktreeRoot: ' + (currentValue || '(default: {{mainWorktree}}.worktrees)'),
+        'info'
+      );
       return;
     }
 
@@ -69,30 +87,33 @@ export async function cmdSettings(
       return;
     }
 
-    const defaults: Record<'worktreeRoot' | 'onCreate', string> = {
-      worktreeRoot: '(default: {{mainWorktree}}.worktrees)',
-      onCreate: '(none)',
-    };
-    ctx.ui.notify(`${resolvedKey}: ${defaults[resolvedKey]}`, 'info');
+    ctx.ui.notify(`${resolvedKey}: (none)`, 'info');
     return;
   }
 
-  const newSettings = { ...currentSettings };
+  const setFields: WorktreeSettingsConfig = {};
+  const clearKeys: (keyof WorktreeSettingsConfig)[] = [];
+  let confirmationMessage: string;
 
   if (value === '' || value === '""' || value === 'null' || value === 'clear') {
-    delete newSettings[resolvedKey];
-    delete newSettings.parentDir;
-    ctx.ui.notify(`✓ Cleared ${resolvedKey}`, 'info');
-  } else {
-    newSettings[resolvedKey] = value;
+    clearKeys.push(resolvedKey);
     if (resolvedKey === 'worktreeRoot') {
-      delete newSettings.parentDir;
+      clearKeys.push('parentDir');
     }
-    ctx.ui.notify(`✓ Set ${resolvedKey} = "${value}"`, 'info');
+    confirmationMessage = `✓ Cleared ${resolvedKey}`;
+  } else {
+    setFields[resolvedKey] = value;
+    if (resolvedKey === 'worktreeRoot') {
+      clearKeys.push('parentDir');
+    }
+    confirmationMessage = `✓ Set ${resolvedKey} = "${value}"`;
   }
 
   try {
-    // await deps.configService.save(newSettings);
+    await saveWorktreeSettings(deps.configService, {
+      fallback: { set: setFields, clear: clearKeys },
+    });
+    ctx.ui.notify(confirmationMessage, 'info');
   } catch (err) {
     ctx.ui.notify(`Failed to save settings: ${(err as Error).message}`, 'error');
   }

--- a/src/cmds/cmdStatus.ts
+++ b/src/cmds/cmdStatus.ts
@@ -1,4 +1,6 @@
 import type { ExtensionCommandContext } from '@mariozechner/pi-coding-agent';
+import { existsSync } from 'node:fs';
+import type { CommandDeps } from '../types.ts';
 import {
   getCurrentBranch,
   getMainWorktreePath,
@@ -8,7 +10,11 @@ import {
   listWorktrees,
 } from '../services/git.ts';
 
-export async function cmdStatus(_args: string, ctx: ExtensionCommandContext): Promise<void> {
+export async function cmdStatus(
+  _args: string,
+  ctx: ExtensionCommandContext,
+  deps: CommandDeps
+): Promise<void> {
   if (!isGitRepo(ctx.cwd)) {
     ctx.ui.notify('Not in a git repository', 'error');
     return;
@@ -19,6 +25,8 @@ export async function cmdStatus(_args: string, ctx: ExtensionCommandContext): Pr
   const project = getProjectName(ctx.cwd);
   const branch = getCurrentBranch(ctx.cwd);
   const worktrees = listWorktrees(ctx.cwd);
+  const configPath = deps.configService.getConfigPath('home');
+  const configExists = existsSync(configPath);
 
   const status = [
     `Project: ${project}`,
@@ -27,6 +35,7 @@ export async function cmdStatus(_args: string, ctx: ExtensionCommandContext): Pr
     `Is worktree: ${isWt ? 'Yes' : 'No (main repository)'}`,
     `Main worktree: ${mainPath}`,
     `Total worktrees: ${worktrees.length}`,
+    `Config file: ${configPath} ${configExists ? '(exists)' : '(not yet created)'}`,
   ];
 
   ctx.ui.notify(status.join('\n'), 'info');

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,12 @@ Commands:
   /worktree prune                  Clean up stale references
   /worktree templates              Show template variables preview
 
-Configuration (~/.pi/agent/pi-worktrees.config.json):
+Configuration file:
+  Home (default):  ~/.pi/agent/pi-worktrees.config.json
+  Project (opt-in): <git root>/.pi/pi-worktrees.config.json
+  Run '/worktree status' to see the resolved absolute path.
+
+Example config:
   {
     "worktrees": {
       "github.com/org/repo": {
@@ -43,11 +48,15 @@ Configuration (~/.pi/agent/pi-worktrees.config.json):
         "onCreate": ["mise install", "bun install"],
         "onSwitch": "mise run dev:resume",
         "onBeforeRemove": "bun test",
-        "branchNameGenerator": "pi -p 'branch name for $PI_WORKTREE_PROMPT' --model local/model",
+        "branchNameGenerator": "pi -p 'branch name for $PI_WORKTREE_PROMPT' --model local/model"
       },
       "github.com/org/*": {
         "worktreeRoot": "~/work/org-other",
         "onCreate": "make setup"
+      },
+      "**": {
+        "worktreeRoot": "{{mainWorktree}}.worktrees",
+        "onCreate": "mise setup"
       }
     },
     "matchingStrategy": "fail-on-tie",
@@ -58,11 +67,7 @@ Configuration (~/.pi/agent/pi-worktrees.config.json):
     "onCreateCmdDisplayError": "[ ] {{cmd}} [ERROR]",
     "onCreateCmdDisplayPendingColor": "dim",
     "onCreateCmdDisplaySuccessColor": "success",
-    "onCreateCmdDisplayErrorColor": "error",
-    "worktree": {
-      "worktreeRoot": "~/.worktrees/{{project}}",
-      "onCreate": "mise setup"
-    }
+    "onCreateCmdDisplayErrorColor": "error"
   }
 
 Pattern matching: exact URL > most-specific glob > fallback (worktree)

--- a/src/services/config/config.ts
+++ b/src/services/config/config.ts
@@ -1,4 +1,6 @@
 import { createConfigService } from '@zenobius/pi-extension-config';
+import { homedir } from 'node:os';
+import path from 'node:path';
 import { Parse } from 'typebox/value';
 
 import { migration as migration_01 } from './migrations/01-flat-single.ts';
@@ -150,14 +152,103 @@ export async function createPiWorktreeConfigService() {
     };
   };
 
+  const getConfigPath = (scope: 'home' | 'project' = 'home'): string => {
+    // Mirrors the file layout used by @zenobius/pi-extension-config.
+    if (scope === 'home') {
+      return path.join(homedir(), '.pi', 'agent', 'pi-worktrees.config.json');
+    }
+
+    return path.join(process.cwd(), '.pi', 'pi-worktrees.config.json');
+  };
+
+  // Direct access to the underlying store's save (the service's own `save`
+  // wrapper takes a full config object and is kept for backwards compatibility).
+  const persist = (scope: 'home' | 'project' = 'home') => store.save(scope);
+
   const service = {
     ...store,
     worktrees,
     current,
     save,
+    persist,
+    getConfigPath,
   };
 
   return service;
+}
+
+type WorktreeSettingsKey = keyof WorktreeSettingsConfig;
+
+type PatternUpdate = {
+  set?: WorktreeSettingsConfig;
+  clear?: WorktreeSettingsKey[];
+};
+
+function applyPatternUpdate(
+  existing: WorktreeSettingsConfig | undefined,
+  update: PatternUpdate
+): WorktreeSettingsConfig {
+  const base: WorktreeSettingsConfig = { ...(existing ?? {}) };
+
+  if (update.clear) {
+    for (const key of update.clear) {
+      delete base[key];
+    }
+  }
+
+  if (update.set) {
+    for (const [key, value] of Object.entries(update.set) as [
+      WorktreeSettingsKey,
+      WorktreeSettingsConfig[WorktreeSettingsKey],
+    ][]) {
+      if (value === undefined) {
+        delete base[key];
+        continue;
+      }
+
+      (base as Record<string, unknown>)[key] = value;
+    }
+  }
+
+  return base;
+}
+
+/**
+ * Merge and persist worktree settings without requiring callers to reason about
+ * the full `PiWorktreeConfig` shape. Accepts either a fallback settings update
+ * (written to the `"**"` pattern) and/or explicit per-pattern overrides.
+ *
+ * Each update can both set keys (`set`) and clear keys (`clear`). Clears are
+ * applied first, so a caller can atomically swap a key's value.
+ *
+ * `scope` defaults to `'home'`; `'project'` is accepted for future UI support
+ * but is not yet surfaced through `/worktree` commands.
+ */
+export async function saveWorktreeSettings(
+  configService: PiWorktreeConfigService,
+  update: {
+    fallback?: PatternUpdate;
+    repo?: Record<string, PatternUpdate>;
+    scope?: 'home' | 'project';
+  }
+): Promise<void> {
+  const current = configService.config.worktrees ?? {};
+  const next: Record<string, WorktreeSettingsConfig> = { ...current };
+
+  if (update.fallback) {
+    next['**'] = applyPatternUpdate(next['**'], update.fallback);
+  }
+
+  if (update.repo) {
+    for (const [pattern, patternUpdate] of Object.entries(update.repo)) {
+      next[pattern] = applyPatternUpdate(next[pattern], patternUpdate);
+    }
+  }
+
+  const scope = update.scope ?? 'home';
+  await configService.set('worktrees', next, scope);
+  await configService.persist(scope);
+  await configService.reload();
 }
 
 export const DefaultWorktreeSettings: WorktreeSettingsConfig = {

--- a/tests/cmds/cmdInit.persistence.test.ts
+++ b/tests/cmds/cmdInit.persistence.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cmdInit } from '../../src/cmds/cmdInit.ts';
+import type { CommandDeps } from '../../src/types.ts';
+
+type FakeStore = {
+  worktrees: Record<string, Record<string, unknown>>;
+  persistCalls: number;
+  reloadCalls: number;
+};
+
+function createFakeDeps(initial: FakeStore['worktrees'] = {}): {
+  deps: CommandDeps;
+  store: FakeStore;
+} {
+  const store: FakeStore = {
+    worktrees: JSON.parse(JSON.stringify(initial)),
+    persistCalls: 0,
+    reloadCalls: 0,
+  };
+
+  const deps = {
+    settings: initial['**'] ?? {},
+    configService: {
+      get config() {
+        return { worktrees: store.worktrees };
+      },
+      set: vi.fn(async (key: string, value: unknown) => {
+        if (key === 'worktrees') {
+          store.worktrees = value as FakeStore['worktrees'];
+        }
+      }),
+      persist: vi.fn(async () => {
+        store.persistCalls += 1;
+      }),
+      reload: vi.fn(async () => {
+        store.reloadCalls += 1;
+      }),
+      getConfigPath: vi.fn(() => '/fake/home/.pi/agent/pi-worktrees.config.json'),
+    } as unknown as CommandDeps['configService'],
+    statusService: {} as CommandDeps['statusService'],
+  } as CommandDeps;
+
+  return { deps, store };
+}
+
+function createFakeCtx(scripted: {
+  select?: unknown;
+  inputs?: (string | undefined)[];
+  confirm?: boolean;
+}) {
+  const notify = vi.fn();
+  const inputs = [...(scripted.inputs ?? [])];
+  const ctx = {
+    cwd: '/repo',
+    hasUI: true,
+    ui: {
+      notify,
+      select: vi.fn(async () => scripted.select),
+      input: vi.fn(async () => inputs.shift()),
+      confirm: vi.fn(async () => scripted.confirm ?? true),
+    },
+  };
+
+  return { ctx, notify };
+}
+
+describe('cmdInit persistence', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists all four hooks to the "**" fallback', async () => {
+    const { deps, store } = createFakeDeps();
+    const { ctx, notify } = createFakeCtx({
+      select: 'Default ({{mainWorktree}}.worktrees)',
+      inputs: ['make setup', 'echo switched', 'bun test'],
+      confirm: true,
+    });
+
+    await cmdInit('', ctx as never, deps);
+
+    expect(deps.configService.set).toHaveBeenCalledWith(
+      'worktrees',
+      {
+        '**': {
+          onCreate: 'make setup',
+          onSwitch: 'echo switched',
+          onBeforeRemove: 'bun test',
+        },
+      },
+      'home'
+    );
+    expect(store.persistCalls).toBe(1);
+    expect(store.reloadCalls).toBe(1);
+
+    const successNotices = notify.mock.calls
+      .map((call) => ({ msg: String(call[0]), level: call[1] }))
+      .filter((entry) => entry.msg.startsWith('✓'));
+    expect(successNotices).toHaveLength(1);
+    expect(successNotices[0].msg).toContain('Settings saved');
+  });
+
+  it('emits the success notice only after save resolves', async () => {
+    const { deps } = createFakeDeps();
+    const saveError = new Error('disk full');
+    (deps.configService.persist as ReturnType<typeof vi.fn>).mockRejectedValueOnce(saveError);
+
+    const { ctx, notify } = createFakeCtx({
+      select: 'Default ({{mainWorktree}}.worktrees)',
+      inputs: ['make setup', '', ''],
+      confirm: true,
+    });
+
+    await cmdInit('', ctx as never, deps);
+
+    const messages = notify.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((m) => m.startsWith('✓ Settings saved'))).toBe(false);
+    expect(messages.some((m) => m.includes('Failed to save settings'))).toBe(true);
+    expect(messages.some((m) => m.includes('disk full'))).toBe(true);
+  });
+
+  it('does not call set or persist when the user cancels the confirmation', async () => {
+    const { deps } = createFakeDeps();
+    const { ctx } = createFakeCtx({
+      select: 'Default ({{mainWorktree}}.worktrees)',
+      inputs: ['make setup', '', ''],
+      confirm: false,
+    });
+
+    await cmdInit('', ctx as never, deps);
+
+    expect(deps.configService.set).not.toHaveBeenCalled();
+    expect(deps.configService.persist).not.toHaveBeenCalled();
+  });
+
+  it('clears previously-set hooks when the user empties the prompt', async () => {
+    const { deps } = createFakeDeps({
+      '**': {
+        onCreate: 'old setup',
+        onSwitch: 'old switch',
+        onBeforeRemove: 'old remove',
+      },
+    });
+    const { ctx } = createFakeCtx({
+      select: 'Default ({{mainWorktree}}.worktrees)',
+      inputs: ['new setup', '', ''],
+      confirm: true,
+    });
+
+    await cmdInit('', ctx as never, deps);
+
+    expect(deps.configService.set).toHaveBeenCalledWith(
+      'worktrees',
+      {
+        '**': {
+          onCreate: 'new setup',
+        },
+      },
+      'home'
+    );
+  });
+});

--- a/tests/cmds/cmdList.switch.integration.test.ts
+++ b/tests/cmds/cmdList.switch.integration.test.ts
@@ -73,4 +73,49 @@ describe('cmdList onSwitch integration', () => {
     expect(notifiedText).toContain('onSwitch steps:');
     expect(notifiedText).toContain('echo switched');
   });
+
+  it('prints path + guidance when no onSwitch is configured', async () => {
+    select.mockResolvedValue(`feature/feature-a\n  ${worktreePath}`);
+
+    const deps: CommandDeps = {
+      settings: {},
+      configService: {
+        current: vi.fn(() => ({
+          project: 'repo',
+          mainWorktree: '/main/repo',
+          logfile: '/tmp/pi-worktree-{sessionId}-{name}.log',
+          onCreateDisplayOutputMaxLines: 5,
+          onCreateCmdDisplayPending: '[ ] {{cmd}}',
+          onCreateCmdDisplaySuccess: '[x] {{cmd}}',
+          onCreateCmdDisplayError: '[ ] {{cmd}} [ERROR]',
+          onCreateCmdDisplayPendingColor: 'dim',
+          onCreateCmdDisplaySuccessColor: 'success',
+          onCreateCmdDisplayErrorColor: 'error',
+        })),
+      } as unknown as CommandDeps['configService'],
+      statusService: {
+        busy: vi.fn(() => vi.fn()),
+        positive: vi.fn(),
+        critical: vi.fn(),
+      } as unknown as CommandDeps['statusService'],
+    };
+
+    const ctx = {
+      cwd: '/main/repo',
+      hasUI: true,
+      ui: { notify, select },
+    };
+
+    await cmdList('', ctx as never, deps);
+
+    const notifiedText = notify.mock.calls.map(([msg]) => String(msg)).join('\n');
+    expect(notifiedText).toContain(`Worktree path: ${worktreePath}`);
+    expect(notifiedText).toContain('Branch:');
+    // Must NOT include the old terse message.
+    expect(notifiedText).not.toMatch(/^No onSwitch configured for: /m);
+    // Must describe the current behavior and offer actionable next steps.
+    expect(notifiedText).toMatch(/does not\s+redirect the running pi session/);
+    expect(notifiedText).toContain(`cd ${worktreePath} && pi`);
+    expect(notifiedText).toContain('/worktree settings onSwitch');
+  });
 });

--- a/tests/cmds/cmdSettings.persistence.test.ts
+++ b/tests/cmds/cmdSettings.persistence.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cmdSettings } from '../../src/cmds/cmdSettings.ts';
+import type { CommandDeps } from '../../src/types.ts';
+
+type FakeStore = {
+  worktrees: Record<string, Record<string, unknown>>;
+  persistCalls: number;
+};
+
+function createFakeDeps(initial: FakeStore['worktrees'] = {}): {
+  deps: CommandDeps;
+  store: FakeStore;
+} {
+  const store: FakeStore = {
+    worktrees: JSON.parse(JSON.stringify(initial)),
+    persistCalls: 0,
+  };
+
+  const deps = {
+    settings: initial['**'] ?? {},
+    configService: {
+      get config() {
+        return { worktrees: store.worktrees };
+      },
+      set: vi.fn(async (key: string, value: unknown) => {
+        if (key === 'worktrees') {
+          store.worktrees = value as FakeStore['worktrees'];
+        }
+      }),
+      persist: vi.fn(async () => {
+        store.persistCalls += 1;
+      }),
+      reload: vi.fn(async () => {}),
+      getConfigPath: vi.fn(() => '/fake/home/.pi/agent/pi-worktrees.config.json'),
+    } as unknown as CommandDeps['configService'],
+    statusService: {} as CommandDeps['statusService'],
+  } as CommandDeps;
+
+  return { deps, store };
+}
+
+function createCtx() {
+  const notify = vi.fn();
+  const ctx = {
+    cwd: '/repo',
+    hasUI: true,
+    ui: { notify },
+  };
+  return { ctx, notify };
+}
+
+describe('cmdSettings persistence', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts onSwitch as a valid setting key and persists it', async () => {
+    const { deps, store } = createFakeDeps();
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('onSwitch "echo switched"', ctx as never, deps);
+
+    expect(store.worktrees).toEqual({
+      '**': { onSwitch: 'echo switched' },
+    });
+    expect(store.persistCalls).toBe(1);
+    const messages = notify.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((m) => m === '✓ Set onSwitch = "echo switched"')).toBe(true);
+    expect(messages.some((m) => m.includes('Invalid setting key'))).toBe(false);
+  });
+
+  it('accepts onBeforeRemove and branchNameGenerator as valid keys', async () => {
+    const { deps } = createFakeDeps();
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('onBeforeRemove "bun test"', ctx as never, deps);
+    await cmdSettings('branchNameGenerator "pi gen"', ctx as never, deps);
+
+    const messages = notify.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((m) => m.includes('Invalid setting key'))).toBe(false);
+    expect(messages).toContain('✓ Set onBeforeRemove = "bun test"');
+    expect(messages).toContain('✓ Set branchNameGenerator = "pi gen"');
+  });
+
+  it('clears onSwitch when value is "clear"', async () => {
+    const { deps, store } = createFakeDeps({
+      '**': { onCreate: 'keep me', onSwitch: 'to remove' },
+    });
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('onSwitch clear', ctx as never, deps);
+
+    expect(store.worktrees).toEqual({
+      '**': { onCreate: 'keep me' },
+    });
+    const messages = notify.mock.calls.map((call) => String(call[0]));
+    expect(messages).toContain('✓ Cleared onSwitch');
+  });
+
+  it('does not emit success notice when persist fails', async () => {
+    const { deps } = createFakeDeps();
+    (deps.configService.persist as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('disk full')
+    );
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('onCreate "echo hi"', ctx as never, deps);
+
+    const messages = notify.mock.calls.map((call) => ({
+      msg: String(call[0]),
+      level: call[1],
+    }));
+    expect(messages.some((m) => m.msg.startsWith('✓ Set'))).toBe(false);
+    expect(messages.some((m) => m.msg.includes('Failed to save settings'))).toBe(true);
+    expect(messages.some((m) => m.msg.includes('disk full'))).toBe(true);
+  });
+
+  it('rejects unknown keys without calling set/persist', async () => {
+    const { deps } = createFakeDeps();
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('bogusKey value', ctx as never, deps);
+
+    expect(deps.configService.set).not.toHaveBeenCalled();
+    expect(deps.configService.persist).not.toHaveBeenCalled();
+    const messages = notify.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((m) => m.includes('Invalid setting key: "bogusKey"'))).toBe(true);
+  });
+
+  it('lists every configured field including onSwitch/onBeforeRemove when called with no args', async () => {
+    const { deps } = createFakeDeps({
+      '**': {
+        worktreeRoot: '~/wt',
+        onCreate: 'echo go',
+        onSwitch: 'echo switched',
+        onBeforeRemove: 'bun test',
+        branchNameGenerator: 'pi gen',
+      },
+    });
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('', ctx as never, deps);
+
+    const fullText = notify.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(fullText).toContain('worktreeRoot:');
+    expect(fullText).toContain('onCreate:');
+    expect(fullText).toContain('onSwitch:');
+    expect(fullText).toContain('onBeforeRemove:');
+    expect(fullText).toContain('branchNameGenerator:');
+    expect(fullText).toContain('Config file: /fake/home/.pi/agent/pi-worktrees.config.json');
+  });
+
+  it('treats parentDir as a deprecated alias and migrates to worktreeRoot', async () => {
+    const { deps, store } = createFakeDeps();
+    const { ctx, notify } = createCtx();
+
+    await cmdSettings('parentDir "~/legacy"', ctx as never, deps);
+
+    expect(store.worktrees).toEqual({
+      '**': { worktreeRoot: '~/legacy' },
+    });
+    const messages = notify.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((m) => m.includes('deprecated'))).toBe(true);
+    expect(messages).toContain('✓ Set worktreeRoot = "~/legacy"');
+  });
+});

--- a/tests/services/saveWorktreeSettings.test.ts
+++ b/tests/services/saveWorktreeSettings.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PiWorktreeConfig } from '../../src/services/config/schema.ts';
+import {
+  createPiWorktreeConfigService,
+  saveWorktreeSettings,
+} from '../../src/services/config/config.ts';
+
+type MockStore = {
+  config: PiWorktreeConfig;
+  ready: Promise<void>;
+  set: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+  save: ReturnType<typeof vi.fn>;
+  events: { on: ReturnType<typeof vi.fn> };
+};
+
+const createConfigServiceMock = vi.fn();
+
+vi.mock('@zenobius/pi-extension-config', () => ({
+  createConfigService: createConfigServiceMock,
+}));
+
+function createMockStore(initialConfig: PiWorktreeConfig = {}): MockStore {
+  const store: MockStore = {
+    config: JSON.parse(JSON.stringify(initialConfig)),
+    ready: Promise.resolve(),
+    set: vi.fn(async (key: string, value: unknown) => {
+      (store.config as Record<string, unknown>)[key] = value;
+    }),
+    reload: vi.fn(async () => {}),
+    save: vi.fn(async () => {}),
+    events: { on: vi.fn() },
+  };
+
+  return store;
+}
+
+let store: MockStore;
+
+beforeEach(() => {
+  store = createMockStore();
+  createConfigServiceMock.mockReset();
+  createConfigServiceMock.mockImplementation(async () => store);
+});
+
+describe('saveWorktreeSettings', () => {
+  it('writes a new fallback pattern when none exists', async () => {
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      fallback: { set: { worktreeRoot: '~/wt', onCreate: 'make setup' } },
+    });
+
+    expect(store.set).toHaveBeenCalledWith(
+      'worktrees',
+      { '**': { worktreeRoot: '~/wt', onCreate: 'make setup' } },
+      'home'
+    );
+    expect(store.save).toHaveBeenCalledWith('home');
+    expect(store.reload).toHaveBeenCalled();
+  });
+
+  it('merges into an existing fallback pattern', async () => {
+    store = createMockStore({
+      worktrees: {
+        '**': { worktreeRoot: '~/existing', onCreate: 'echo keep-me' },
+      },
+    });
+    createConfigServiceMock.mockImplementation(async () => store);
+
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      fallback: { set: { onSwitch: 'echo switched' } },
+    });
+
+    const [, value] = store.set.mock.calls[0];
+    expect(value).toEqual({
+      '**': {
+        worktreeRoot: '~/existing',
+        onCreate: 'echo keep-me',
+        onSwitch: 'echo switched',
+      },
+    });
+  });
+
+  it('clears specific keys without touching others', async () => {
+    store = createMockStore({
+      worktrees: {
+        '**': {
+          worktreeRoot: '~/wt',
+          onCreate: 'echo go',
+          onSwitch: 'echo switched',
+          onBeforeRemove: 'echo remove',
+        },
+      },
+    });
+    createConfigServiceMock.mockImplementation(async () => store);
+
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      fallback: { clear: ['onSwitch', 'onBeforeRemove'] },
+    });
+
+    const [, value] = store.set.mock.calls[0];
+    expect(value).toEqual({
+      '**': {
+        worktreeRoot: '~/wt',
+        onCreate: 'echo go',
+      },
+    });
+  });
+
+  it('applies clear before set so a key can be replaced atomically', async () => {
+    store = createMockStore({
+      worktrees: {
+        '**': { onCreate: 'echo old' },
+      },
+    });
+    createConfigServiceMock.mockImplementation(async () => store);
+
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      fallback: { clear: ['onCreate'], set: { onCreate: 'echo new' } },
+    });
+
+    const [, value] = store.set.mock.calls[0];
+    expect(value).toEqual({ '**': { onCreate: 'echo new' } });
+  });
+
+  it('preserves unrelated repo patterns while updating fallback', async () => {
+    store = createMockStore({
+      worktrees: {
+        'github.com/org/*': { worktreeRoot: '~/org', onCreate: 'echo org' },
+        '**': { worktreeRoot: '~/default' },
+      },
+    });
+    createConfigServiceMock.mockImplementation(async () => store);
+
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      fallback: { set: { onCreate: 'echo default' } },
+    });
+
+    const [, value] = store.set.mock.calls[0];
+    expect(value).toEqual({
+      'github.com/org/*': { worktreeRoot: '~/org', onCreate: 'echo org' },
+      '**': { worktreeRoot: '~/default', onCreate: 'echo default' },
+    });
+  });
+
+  it('writes per-pattern repo overrides', async () => {
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      repo: {
+        'github.com/org/repo': { set: { onCreate: 'bun install' } },
+      },
+    });
+
+    const [, value] = store.set.mock.calls[0];
+    expect(value).toEqual({
+      'github.com/org/repo': { onCreate: 'bun install' },
+    });
+  });
+
+  it('defaults scope to "home" and forwards explicit scope to set+save', async () => {
+    const service = await createPiWorktreeConfigService();
+
+    await saveWorktreeSettings(service, {
+      fallback: { set: { onCreate: 'echo hi' } },
+      scope: 'project',
+    });
+
+    expect(store.set).toHaveBeenCalledWith('worktrees', expect.any(Object), 'project');
+    expect(store.save).toHaveBeenCalledWith('project');
+  });
+});
+
+describe('PiWorktreeConfigService.getConfigPath', () => {
+  it('returns the home config path by default', async () => {
+    const service = await createPiWorktreeConfigService();
+    const homePath = service.getConfigPath();
+    expect(homePath).toMatch(/\.pi\/agent\/pi-worktrees\.config\.json$/);
+  });
+
+  it('returns the project config path when requested', async () => {
+    const service = await createPiWorktreeConfigService();
+    const projectPath = service.getConfigPath('project');
+    expect(projectPath).toMatch(/\.pi\/pi-worktrees\.config\.json$/);
+    expect(projectPath).not.toMatch(/\.pi\/agent\//);
+  });
+});


### PR DESCRIPTION
/worktree init and /worktree settings weren't working as expected - settings weren't getting persisted anywhere.

Also, some of the hooks (onSwitch, onBeforeRemove, etc) weren't fully documented/integrated. 

I'm separately making some updates to how the worktree switching works (based on updates made to pi since this last release) - will post that soon.