### PR TITLE
docs: fix config filename for pi-worktrees settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This creates a new Zellij tab with Neovim and Pi running in the new worktree pat
 
 ## Configuration
 
-Settings live in `~/.pi/agent/pi-worktrees-settings.json`.
+Settings live in `~/.pi/agent/pi-worktrees.config.json`.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- fix README configuration path to match runtime config file
- replace `~/.pi/agent/pi-worktrees-settings.json` with `~/.pi/agent/pi-worktrees.config.json`

## Why
The documented filename did not match what the extension reads, which makes users think `worktreeRoot` is ignored when they edit the wrong file.

Closes #14
