### PR TITLE
fix: persist /worktree settings updates

### DIFF
--- a/src/cmds/cmdSettings.ts
+++ b/src/cmds/cmdSettings.ts
@@ -77,8 +77,10 @@ export async function cmdSettings(
     return;
   }
 
-  const newSettings = { ...currentSettings };
-
+  const resolvedCurrent = deps.configService.current(ctx) as { matchedPattern?: string };
+  const matchedPattern = resolvedCurrent.matchedPattern ?? '**';
+  const configuredWorktrees = deps.configService.config.worktrees ?? {};
+  const newSettings = { ...(configuredWorktrees[matchedPattern] ?? {}) };
   if (value === '' || value === '""' || value === 'null' || value === 'clear') {
     delete newSettings[resolvedKey];
     delete newSettings.parentDir;
@@ -91,8 +93,13 @@ export async function cmdSettings(
     ctx.ui.notify(`✓ Set ${resolvedKey} = "${value}"`, 'info');
   }
 
+  const nextWorktrees = { ...configuredWorktrees, [matchedPattern]: newSettings };
+  if (matchedPattern !== '**' && Object.keys(newSettings).length === 0) {
+    delete nextWorktrees[matchedPattern];
+  }
+
   try {
-    // await deps.configService.save(newSettings);
+    await deps.configService.save({ worktrees: nextWorktrees });
   } catch (err) {
     ctx.ui.notify(`Failed to save settings: ${(err as Error).message}`, 'error');
   }

--- a/tests/cmds/cmdSettings.integration.test.ts
+++ b/tests/cmds/cmdSettings.integration.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { cmdSettings } from '../../src/cmds/cmdSettings.ts';
+import type { CommandDeps } from '../../src/types.ts';
+
+function createDeps(overrides?: {
+  matchedPattern?: string;
+  worktrees?: Record<string, Record<string, unknown>>;
+}) {
+  const matchedPattern = overrides?.matchedPattern ?? 'github.com/org/repo';
+  const worktrees = overrides?.worktrees ?? {
+    [matchedPattern]: {
+      onCreate: 'echo "Created {{path}}"',
+    },
+  };
+
+  const current = {
+    matchedPattern,
+    worktreeRoot: '/tmp/repo.worktrees',
+    onCreate: 'echo "Created {{path}}"',
+  };
+
+  const configService = {
+    current: vi.fn(() => current),
+    config: { worktrees },
+    save: vi.fn(async () => {}),
+  } as unknown as CommandDeps['configService'];
+
+  return {
+    settings: current as CommandDeps['settings'],
+    configService,
+    statusService: {} as CommandDeps['statusService'],
+  } satisfies CommandDeps;
+}
+
+describe('cmdSettings persistence integration', () => {
+  it('persists updated worktreeRoot for the matched pattern', async () => {
+    const deps = createDeps();
+    const notify = vi.fn();
+    const ctx = { cwd: '/repo', ui: { notify } };
+
+    await cmdSettings('worktreeRoot /custom/path', ctx as never, deps);
+
+    expect(deps.configService.save).toHaveBeenCalledWith({
+      worktrees: {
+        'github.com/org/repo': {
+          onCreate: 'echo "Created {{path}}"',
+          worktreeRoot: '/custom/path',
+        },
+      },
+    });
+  });
+
+  it('clears worktreeRoot/parentDir for the matched pattern and keeps other settings', async () => {
+    const deps = createDeps({
+      worktrees: {
+        'github.com/org/repo': {
+          onCreate: 'echo "Created {{path}}"',
+          worktreeRoot: '/tmp/repo.worktrees',
+          parentDir: '/tmp/legacy.worktrees',
+        },
+      },
+    });
+    const notify = vi.fn();
+    const ctx = { cwd: '/repo', ui: { notify } };
+
+    await cmdSettings('worktreeRoot clear', ctx as never, deps);
+
+    expect(deps.configService.save).toHaveBeenCalledWith({
+      worktrees: {
+        'github.com/org/repo': {
+          onCreate: 'echo "Created {{path}}"',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- persist `/worktree settings` updates instead of dropping them
- save changes into `worktrees[matchedPattern]` rather than trying to save resolved runtime settings
- preserve existing pattern settings while updating/clearing only the requested key
- remove legacy `parentDir` when setting or clearing `worktreeRoot`
- add integration tests covering set + clear persistence behavior

## Root cause
`cmdSettings` built updates from `deps.settings` (resolved runtime view) and never called `configService.save` (call was commented out). That made changes appear successful in UI while nothing was persisted.

## Verification
- `bun test tests/cmds/cmdSettings.integration.test.ts`
- `mise run lint`

Refs #14
